### PR TITLE
feat: update Ollama service configuration for host networking and hea…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,33 @@
 version: '3.8'
 
 services:
-  # Ollama LLM Service
+
   ollama:
     image: ollama/ollama:latest
     container_name: cratoss-ollama
     restart: unless-stopped
-    ports:
-      - "11434:11434"
+    network_mode: "host"
     volumes:
       - ollama_data:/root/.ollama
     environment:
       - OLLAMA_HOST=0.0.0.0
-    networks:
-      - cratoss-network
+    # Automatically pull the model on startup
+    entrypoint: /bin/sh
+    command: -c "ollama serve & sleep 10 && ollama pull llama3.2 && wait"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
+      # Use a simple shell check if wget/curl are missing, or try wget with different flags
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:11434 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 30s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+      start_period: 600s
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
 
   # Backend RAG Service
   backend:
@@ -43,7 +44,10 @@ services:
       - backend_cache:/root/.cache
     environment:
       - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
+      # Since ollama is in host mode, use the host's IP address (172.17.0.1) or your actual local IP
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       ollama:
         condition: service_healthy


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to improve how the Ollama LLM service is managed and accessed by other services. The changes focus on enhancing startup reliability, simplifying networking, and ensuring the backend service can connect to Ollama consistently.

**Ollama service improvements:**

* Changed `ollama` service to use `network_mode: "host"` instead of custom networks and port mappings, simplifying network configuration and making the service accessible on the host network.
* Added an `entrypoint` and `command` to the `ollama` service to automatically start the Ollama server, wait for it to initialize, and pull the `llama3.2` model on startup.
* Updated the healthcheck to use `wget` for checking service health and increased the `start_period` to 600 seconds to allow more time for model download and initialization.
* Commented out the GPU device reservation section under `deploy` for easier configuration and to avoid deployment issues on systems without GPUs.

**Backend service connectivity:**

* Updated the `OLLAMA_BASE_URL` environment variable in the `backend` service to use `host.docker.internal`, ensuring it can reliably connect to the Ollama service running in host mode. Added `extra_hosts` to map `host.docker.internal` to the Docker host gateway.…lthcheck